### PR TITLE
Match engines specified in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ flow-typed
 
 # Editor
 .idea
+
+# npm
+package-lock.json
+npm-shrinkwrap.json

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "flow": "flow",
     "flow-typed": "flow-typed install",
     "lint": "eslint --cache --format=node_modules/eslint-formatter-pretty .",
-    "lint-fix": "npm run lint -- --fix; exit 0",
+    "lint-fix": "yarn lint -- --fix; exit 0",
     "postlint-fix": "prettier --ignore-path .eslintignore --single-quote --write '**/*.js'",
     "spec": "jest",
-    "postinstall": "npm run flow-typed",
-    "test": "npm run spec"
+    "postinstall": "yarn flow-typed",
+    "test": "yarn spec"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint-fix"
+      "pre-commit": "yarn lint-fix"
     }
   },
   "repository": {
@@ -48,10 +48,11 @@
     "flow-bin": "^0.75.0",
     "flow-typed": "^2.4.0",
     "husky": "^1.0.0-rc.1",
-    "jest-cli": "^23.2.0"
+    "jest-cli": "^23.2.0",
+    "yarn": "^1.6.0"
   },
   "engines": {
-    "node": ">=6",
-    "npm": ">=3"
+    "node": ">=9",
+    "yarn": ">=1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5009,3 +5009,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.6.0:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.9.4.tgz#3b82d8446b652775723900b470d966861976924b"


### PR DESCRIPTION
- `package.json` now has engines `yarn`>=1.60 and `node`>=9 as specified in README.
- Changed all cases of `npm run` to `yarn`
- Added `npm` lockfiles to gitignore